### PR TITLE
Transition postgres to sqlite and litestream

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
-trim_trailing_whitespace = false
-
 [*.{yaml,yml,json,md}]
 indent_size = 2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN env
 # Install litestream (https://litestream.io/install/debian/)
 RUN wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb
 RUN dpkg -i litestream-v0.3.9-linux-amd64.deb
-COPY litestream.yml /etc/litestream.yml
 
 # Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ ENV PATH=${POETRY_HOME}/bin:$PATH \
     DJANGO_SETTINGS_MODULE=lpld.settings
 RUN env
 
+# Install litestream (https://litestream.io/install/debian/)
+RUN wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb
+RUN dpkg -i litestream-v0.3.9-linux-amd64.deb
+COPY litestream.yml /etc/litestream.yml
+
 # Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN chown -R lpld:lpld ${POETRY_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ COPY --chown=lpld:lpld --from=frontend ./lpld/static/comp ./lpld/static/comp
 RUN SECRET_KEY=none ./manage.py collectstatic --noinput --clear
 
 EXPOSE 8000
-CMD gunicorn --bind 0.0.0.0:$PORT lpld.wsgi:application
+CMD ./scripts/run.sh

--- a/README.md
+++ b/README.md
@@ -146,3 +146,29 @@ For the replication and restoration to work you need to create a S3 bucket at so
 The replication is handled in the `./scripts/run.sh` script by wrapping the Gunicorn server process in the Litestream process.
 This is the recommended way to [run Litestream in a container](https://litestream.io/guides/docker/).
 The restoration is handled in the `./scripts/release.sh` script. This script is run by Heroku on every container restart.
+
+### Scale down Heroku Dynos
+
+Heroku has removed their free plan.
+That means having an idle server that is practically not running will start to cost money.
+This is a bit of a pain, because I was using the free Dyno for a staging server for my site.
+My site is not that important and I could probably do without a staging server, but I like having this stop gap between my local setup and the production one.
+
+It turns out, the paid plans for [Heroku are prorated to the second](https://www.heroku.com/pricing).
+I did not know that because I was only running a single paid app and the was on all the time, I never needed any scaling.
+But now this becomes interesting.
+I hardly need the staging server and I am ok with paying for the few times that I need it.
+To not pay the full month for the staging server that I basically never need, I can just scale it down to 0 instances, with:
+
+```console
+heroku ps:scale web=0 -a lpld-io-staging
+```
+
+If I need to access it, I just need to scale it up again.
+
+```console
+heroku ps:scale web=1 -a lpld-io-staging
+```
+
+Autoscaling if not an option, because that is only available on the more expensive plans.
+But for now I am ok with doing it manually.

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -6,4 +6,5 @@ services:
       - "8000:8000"
     environment:
       SECRET_KEY: thisisnotasecrectkey
+      DB_DIR: /data
     command: ["tail", "-f", "/dev/null"]

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -5,16 +5,5 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgres://lpld:lpld@db:5432/lpld # pragma: allowlist secret
       SECRET_KEY: thisisnotasecrectkey
     command: ["tail", "-f", "/dev/null"]
-    depends_on:
-      - db
-
-  db:
-    image: "postgres:13"
-    expose:
-      - 5432
-    environment:
-      POSTGRES_USER: lpld
-      POSTGRES_PASSWORD: lpld

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,4 +12,5 @@ services:
       SECRET_KEY: thisisnotasecrectkey
       DEBUG: "True"
       INTERNAL_IPS: "172.20.0.1"
+      PORT: 8000
     command: ["tail", "-f", "/dev/null"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,22 @@ services:
     volumes:
       - .:/app
       - ./data:/data
-    env_file: .env
     environment:
+      DATABASE_URL: postgres://lpld:lpld@db:5432/lpld # pragma: allowlist secret
       SECRET_KEY: thisisnotasecrectkey
       DEBUG: "True"
       INTERNAL_IPS: "172.20.0.1"
       PORT: 8000
     command: ["tail", "-f", "/dev/null"]
+    depends_on:
+      - db
+
+  db:
+    image: "postgres:13"
+    expose:
+      - 5432
+    volumes:
+      - ./dbdump:/dbdump
+    environment:
+      POSTGRES_USER: lpld
+      POSTGRES_PASSWORD: lpld

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,20 +2,16 @@ services:
   web:
     image: lpld_web
     build: .
+    command: ["tail", "-f", "/dev/null"]
+    depends_on:
+      - db
+    env_file:
+      - .env
     ports:
       - "8000:8000"
     volumes:
       - .:/app
       - ./data:/data
-    environment:
-      DATABASE_URL: postgres://lpld:lpld@db:5432/lpld # pragma: allowlist secret
-      SECRET_KEY: thisisnotasecrectkey
-      DEBUG: "True"
-      INTERNAL_IPS: "172.20.0.1"
-      PORT: 8000
-    command: ["tail", "-f", "/dev/null"]
-    depends_on:
-      - db
 
   db:
     image: "postgres:13"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,21 +7,9 @@ services:
     volumes:
       - .:/app
       - ./data:/data
+    env_file: .env
     environment:
-      DATABASE_URL: postgres://lpld:lpld@db:5432/lpld # pragma: allowlist secret
       SECRET_KEY: thisisnotasecrectkey
       DEBUG: "True"
       INTERNAL_IPS: "172.20.0.1"
     command: ["tail", "-f", "/dev/null"]
-    depends_on:
-      - db
-
-  db:
-    image: "postgres:13"
-    expose:
-      - 5432
-    volumes:
-      - ./dbdump:/dbdump
-    environment:
-      POSTGRES_USER: lpld
-      POSTGRES_PASSWORD: lpld

--- a/heroku.yml
+++ b/heroku.yml
@@ -4,4 +4,4 @@ build:
 release:
   image: web
   command:
-    - ./manage.py check --deploy --fail-level WARNING && ./manage.py createcachetable && ./manage.py migrate --noinput
+    - ./scripts/release.sh

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,6 +1,8 @@
 access-key-id: ${LITESTREAM_KEY_ID}
 secret-access-key: ${LITESTREAM_ACCESS_KEY}
 
+exec: gunicorn --bind 0.0.0.0:${PORT} lpld.wsgi:application
+
 dbs:
   - path: /data/db.sqlite3
     replicas:

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,0 +1,7 @@
+access-key-id: ${LITESTREAM_KEY_ID}
+secret-access-key: ${LITESTREAM_ACCESS_KEY}
+
+dbs:
+  - path: /data/db.sqlite3
+    replicas:
+      - url: s3://${LITESTREAM_BUCKET_HOST}/db.sqlite3

--- a/litestream.yml
+++ b/litestream.yml
@@ -2,6 +2,6 @@ access-key-id: ${LITESTREAM_KEY_ID}
 secret-access-key: ${LITESTREAM_ACCESS_KEY}
 
 dbs:
-  - path: /data/db.sqlite3
+  - path: ${DB_DIR}/db.sqlite3
     replicas:
       - url: s3://${LITESTREAM_BUCKET_HOST}/db.sqlite3

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,8 +1,6 @@
 access-key-id: ${LITESTREAM_KEY_ID}
 secret-access-key: ${LITESTREAM_ACCESS_KEY}
 
-exec: gunicorn --bind 0.0.0.0:${PORT} lpld.wsgi:application
-
 dbs:
   - path: /data/db.sqlite3
     replicas:

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -158,7 +158,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 # https://github.com/jacobian/dj-database-url
 
-DB_DIR = os.environ["DB_DIR"]
+DB_DIR = os.environ.get("DB_DIR", BASE_DIR)
 SQLITE_URL = f"sqlite:///{ Path(DB_DIR).joinpath('db.sqlite3') }"
 DATABASE_URL = os.environ.get(
     "DATABASE_URL",

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -160,14 +160,16 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 # https://github.com/jacobian/dj-database-url
 
-
+SQLITE_URL = f"sqlite:///{ Path(BASE_DIR).joinpath('data/db.sqlite3')}"
 DATABASE_URL = os.environ.get(
     "DATABASE_URL",
-    "sqlite:///" + str(Path(BASE_DIR).joinpath("db.sqlite3")),
+    SQLITE_URL,
 )
 DATABASES = {}
 DATABASES["default"] = dj_database_url.parse(DATABASE_URL)
-
+if DATABASE_URL != SQLITE_URL:
+    # If the default database is not the SQLite database, then also add a second database config for SQLite
+    DATABASES["sqlite"] = dj_database_url.parse(SQLITE_URL)
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -167,9 +167,6 @@ DATABASE_URL = os.environ.get(
 )
 DATABASES = {}
 DATABASES["default"] = dj_database_url.parse(DATABASE_URL)
-if DATABASE_URL != SQLITE_URL:
-    # If the default database is not the SQLite database, then also add a second database config for SQLite
-    DATABASES["sqlite"] = dj_database_url.parse(SQLITE_URL)
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -14,11 +14,9 @@ import os
 from pathlib import Path
 
 import dj_database_url  # type: ignore
-import dotenv
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-dotenv.load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -17,7 +17,6 @@ import dj_database_url  # type: ignore
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("SECRET_KEY")
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
@@ -158,7 +158,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 # https://github.com/jacobian/dj-database-url
 
-SQLITE_URL = f"sqlite:///{ Path(BASE_DIR).joinpath('data/db.sqlite3')}"
+DB_DIR = os.environ["DB_DIR"]
+SQLITE_URL = f"sqlite:///{ Path(DB_DIR).joinpath('db.sqlite3') }"
 DATABASE_URL = os.environ.get(
     "DATABASE_URL",
     SQLITE_URL,

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,7 +15,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "atomicwrites"
@@ -34,10 +34,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "backports.zoneinfo"
@@ -81,7 +81,7 @@ platformdirs = ">=2"
 tomli = ">=0.2.6,<2.0.0"
 typing-extensions = [
     {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
-    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+    {version = ">=3.10.0.0,<3.10.0.1 || >3.10.0.1", markers = "python_version >= \"3.10\""},
 ]
 
 [package.extras]
@@ -140,7 +140,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -184,8 +184,8 @@ sqlparse = ">=0.2.2"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-bcrypt = ["bcrypt"]
 argon2 = ["argon2-cffi (>=19.1.0)"]
+bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-basic-auth-ip-whitelist"
@@ -199,7 +199,7 @@ python-versions = ">=3.4"
 Django = ">=1.8,<5"
 
 [package.extras]
-lint = ["isort (==5.7.0)", "flake8 (==3.8.4)", "black (==20.8b1)"]
+lint = ["black (==20.8b1)", "flake8 (==3.8.4)", "isort (==5.7.0)"]
 
 [[package]]
 name = "django-debug-toolbar"
@@ -379,7 +379,7 @@ python-versions = "*"
 [package.extras]
 html5lib = ["beautifulsoup4 (>=4.4.1,<5)", "html5lib (>=0.999,<=1.0.1)"]
 lxml = ["lxml (>=4.2.0,<5)"]
-testing = ["tox (>=2.3.1)", "markov-draftjs (==0.1.1)", "memory-profiler (==0.47)", "psutil (==5.4.1)", "coverage (>=4.1.0)", "flake8 (>=3.2.0)", "isort (==4.2.5)", "beautifulsoup4 (>=4.4.1,<5)", "html5lib (>=0.999,<=1.0.1)", "lxml (>=4.2.0,<5)"]
+testing = ["beautifulsoup4 (>=4.4.1,<5)", "coverage (>=4.1.0)", "flake8 (>=3.2.0)", "html5lib (>=0.999,<=1.0.1)", "isort (==4.2.5)", "lxml (>=4.2.0,<5)", "markov-draftjs (==0.1.1)", "memory-profiler (==0.47)", "psutil (==5.4.1)", "tox (>=2.3.1)"]
 
 [[package]]
 name = "et-xmlfile"
@@ -401,8 +401,8 @@ python-versions = ">=3.6"
 Faker = ">=0.7.0"
 
 [package.extras]
-dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoengine", "wheel (>=0.32.0)", "tox", "zest.releaser"]
-doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
@@ -435,6 +435,9 @@ description = "WSGI HTTP Server for UNIX"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[package.dependencies]
+setuptools = ">=3.0"
 
 [package.extras]
 eventlet = ["eventlet (>=0.24.1)"]
@@ -470,10 +473,10 @@ six = ">=1.9"
 webencodings = "*"
 
 [package.extras]
-lxml = ["lxml"]
-genshi = ["genshi"]
+all = ["chardet (>=2.2)", "genshi", "lxml"]
 chardet = ["chardet (>=2.2)"]
-all = ["lxml", "chardet (>=2.2)", "genshi"]
+genshi = ["genshi"]
+lxml = ["lxml"]
 
 [[package]]
 name = "idna"
@@ -495,9 +498,9 @@ python-versions = ">=3.7"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -516,10 +519,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jmespath"
@@ -647,8 +650,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psycopg2"
@@ -727,7 +730,7 @@ pytest = ">=5.4.0"
 
 [package.extras]
 docs = ["sphinx", "sphinx-rtd-theme"]
-testing = ["django", "django-configurations (>=2.0)"]
+testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -739,17 +742,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "python-dotenv"
-version = "0.16.0"
-description = "Read key-value pairs from a .env file and set them as environment variables"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
@@ -783,7 +775,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "s3transfer"
@@ -819,15 +811,28 @@ celery = ["celery (>=3)"]
 chalice = ["chalice (>=1.16.0)"]
 django = ["django (>=1.8)"]
 falcon = ["falcon (>=1.4)"]
-flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+flask = ["blinker (>=1.1)", "flask (>=0.11)"]
 httpx = ["httpx (>=0.16.0)"]
-pure_eval = ["pure-eval", "executing", "asttokens"]
+pure-eval = ["asttokens", "executing", "pure-eval"]
 pyspark = ["pyspark (>=2.4.4)"]
-quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
+quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
 rq = ["rq (>=0.6)"]
 sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
 tornado = ["tornado (>=5)"]
+
+[[package]]
+name = "setuptools"
+version = "65.5.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -897,7 +902,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-docs = ["mkdocs-material (>=6.2,<6.3)", "mkdocs (>=1.1,<1.2)"]
+docs = ["mkdocs (>=1.1,<1.2)", "mkdocs-material (>=6.2,<6.3)"]
 
 [[package]]
 name = "toml"
@@ -956,8 +961,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -989,8 +994,8 @@ Willow = ">=1.4,<1.5"
 xlsxwriter = ">=1.2.8,<4.0"
 
 [package.extras]
-testing = ["polib (>=1.1,<2.0)", "djhtml (==1.4.13)", "curlylint (==0.13.1)", "flake8-assertive (==2.0.0)", "doc8 (==0.8.1)", "flake8-print (==2.0.2)", "flake8-comprehensions (==3.8.0)", "flake8-blind-except (==0.1.1)", "isort (==5.6.4)", "flake8 (>=3.6.0)", "black (==22.3.0)", "coverage (>=3.7.0)", "django-pattern-library (>=0.7,<0.8)", "azure-mgmt-frontdoor (>=0.3,<0.4)", "azure-mgmt-cdn (>=5.1,<6.0)", "openpyxl (>=2.6.4)", "freezegun (>=0.3.8)", "boto3 (>=1.16,<1.17)", "Jinja2 (>=3.0,<3.2)", "elasticsearch (>=5.0,<6.0)", "pytz (>=2014.7)", "python-dateutil (>=2.7)"]
-docs = ["myst-parser (==0.17.0)", "sphinx-wagtail-theme (==5.1.1)", "sphinx-autobuild (>=0.6.0)", "Sphinx (>=1.5.2)", "sphinxcontrib-spelling (>=5.4.0,<6)", "pyenchant (>=3.1.1,<4)"]
+docs = ["Sphinx (>=1.5.2)", "myst-parser (==0.17.0)", "pyenchant (>=3.1.1,<4)", "sphinx-autobuild (>=0.6.0)", "sphinx-wagtail-theme (==5.1.1)", "sphinxcontrib-spelling (>=5.4.0,<6)"]
+testing = ["Jinja2 (>=3.0,<3.2)", "azure-mgmt-cdn (>=5.1,<6.0)", "azure-mgmt-frontdoor (>=0.3,<0.4)", "black (==22.3.0)", "boto3 (>=1.16,<1.17)", "coverage (>=3.7.0)", "curlylint (==0.13.1)", "django-pattern-library (>=0.7,<0.8)", "djhtml (==1.4.13)", "doc8 (==0.8.1)", "elasticsearch (>=5.0,<6.0)", "flake8 (>=3.6.0)", "flake8-assertive (==2.0.0)", "flake8-blind-except (==0.1.1)", "flake8-comprehensions (==3.8.0)", "flake8-print (==2.0.2)", "freezegun (>=0.3.8)", "isort (==5.6.4)", "openpyxl (>=2.6.4)", "polib (>=1.1,<2.0)", "python-dateutil (>=2.7)", "pytz (>=2014.7)"]
 
 [[package]]
 name = "wagtail-factories"
@@ -1005,8 +1010,8 @@ factory-boy = ">=2.8.0"
 wagtail = ">=2.0"
 
 [package.extras]
-test = ["flake8-debugger (==3.1.0)", "flake8-blind-except (==0.1.1)", "flake8 (==3.7.8)", "isort (==4.3.21)", "coverage (==4.5.3)", "psycopg2 (>=2.3.1)", "pytest-pythonpath (==0.7.3)", "pytest-cov (==2.7.1)", "pytest-django (==3.9.0)", "pytest (==6.0.1)"]
 docs = ["sphinx (>=1.4.0)"]
+test = ["coverage (==4.5.3)", "flake8 (==3.7.8)", "flake8-blind-except (==0.1.1)", "flake8-debugger (==3.1.0)", "isort (==4.3.21)", "psycopg2 (>=2.3.1)", "pytest (==6.0.1)", "pytest-cov (==2.7.1)", "pytest-django (==3.9.0)", "pytest-pythonpath (==0.7.3)"]
 
 [[package]]
 name = "wagtail-storages"
@@ -1021,7 +1026,7 @@ django-storages = {version = "<2", extras = ["boto3"]}
 Wagtail = ">=2.15,<4.0"
 
 [package.extras]
-testing = ["coverage (==5.0.3)", "factory-boy (==2.12.0)", "moto (==3.1.8)", "black (==22.3.0)", "isort", "flake8"]
+testing = ["black (==22.3.0)", "coverage (==5.0.3)", "factory-boy (==2.12.0)", "flake8", "isort", "moto (==3.1.8)"]
 
 [[package]]
 name = "wagtailmedia"
@@ -1035,7 +1040,7 @@ python-versions = "*"
 wagtail = ">=2.11"
 
 [package.extras]
-testing = ["tox (>=3.24,<4.0)", "coverage (>=3.7.0)", "mock (>=1.0.0)"]
+testing = ["coverage (>=3.7.0)", "mock (>=1.0.0)", "tox (>=3.24,<4.0)"]
 
 [[package]]
 name = "webencodings"
@@ -1054,7 +1059,7 @@ optional = false
 python-versions = ">=3.5, <4"
 
 [package.extras]
-brotli = ["brotli"]
+brotli = ["Brotli"]
 
 [[package]]
 name = "willow"
@@ -1065,7 +1070,7 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
-testing = ["mock (>=3.0,<4.0)", "Wand (>=0.6,<1.0)", "Pillow (>=6.0.0,<10.0.0)"]
+testing = ["Pillow (>=6.0.0,<10.0.0)", "Wand (>=0.6,<1.0)", "mock (>=3.0,<4.0)"]
 
 [[package]]
 name = "xlrd"
@@ -1076,9 +1081,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
-test = ["pytest-cov", "pytest"]
-docs = ["sphinx"]
 build = ["twine", "wheel"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "xlsxwriter"
@@ -1105,13 +1110,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c1cfe5560d622ba76ce3de924e1781f4ffc4ab3a64c637bd7d7073311e0779ed"
+content-hash = "ecce08514a70d5e4eb760843e25855282093d02ad40ba77789bfa9f5644397dc"
 
 [metadata.files]
 anyascii = [
@@ -1435,10 +1440,6 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
-python-dotenv = [
-    {file = "python-dotenv-0.16.0.tar.gz", hash = "sha256:9fa413c37d4652d3fa02fea0ff465c384f5db75eab259c4fc5d0c5b8bf20edd4"},
-    {file = "python_dotenv-0.16.0-py2.py3-none-any.whl", hash = "sha256:31d752f5b748f4e292448c9a0cac6a08ed5e6f4cefab85044462dcad56905cec"},
-]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
@@ -1485,6 +1486,10 @@ s3transfer = [
 sentry-sdk = [
     {file = "sentry-sdk-1.5.7.tar.gz", hash = "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"},
     {file = "sentry_sdk-1.5.7-py2.py3-none-any.whl", hash = "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49"},
+]
+setuptools = [
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ gunicorn = "^20.1.0"
 heroicons = {extras = ["django"], version = "^1.4.0"}
 psycopg2 = "^2.9.1"
 python = "^3.8"
-python-dotenv = "~0.16.0"
 sentry-sdk = "^1.4.3"
 slippers = "^0.3.0"
 wagtail = "~3.0"

--- a/scripts/download_bucket.py
+++ b/scripts/download_bucket.py
@@ -1,14 +1,9 @@
+import os
 import pathlib
 
 import boto3  # type: ignore
-import dotenv
 
-settings = dotenv.dotenv_values(".env")
-bucket_name = settings.get("AWS_STORAGE_BUCKET_NAME", "")
-
-if not bucket_name:
-    print("No bucket name defined.")
-    exit(1)
+bucket_name = os.environ["AWS_STORAGE_BUCKET_NAME"]
 
 target_directory = pathlib.Path("/data") / bucket_name
 target_directory.mkdir(exist_ok=True)
@@ -16,10 +11,10 @@ target_directory.mkdir(exist_ok=True)
 session = boto3.session.Session()
 client = session.client(
     "s3",
-    region_name=settings["AWS_S3_REGION_NAME"],
-    endpoint_url=settings["AWS_S3_ENDPOINT_URL"],
-    aws_access_key_id=settings["AWS_ACCESS_KEY_ID"],
-    aws_secret_access_key=settings["AWS_SECRET_ACCESS_KEY"],
+    region_name=os.environ["AWS_S3_REGION_NAME"],
+    endpoint_url=os.environ["AWS_S3_ENDPOINT_URL"],
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
 )
 
 response = client.list_objects(Bucket=bucket_name)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,1 +1,20 @@
-./manage.py check --deploy --fail-level WARNING && ./manage.py createcachetable && ./manage.py migrate --noinput
+# Bash "strict mode"
+set -euo pipefail
+IFS=$'\n\t'
+
+# Allow missing envar
+set +u
+if [[ -z "$DATABASE_URL" ]]; then
+    echo "DATABASE_URL env var not specified - Using the SQLite database"
+
+    mkdir -p "$DB_DIR"
+    echo "Replicating the SQLite database from bucket"
+    litestream restore -config litestream.yml -if-db-not-exists -if-replica-exists "$DB_DIR/db.sqlite3"
+    chmod -R a+rwX "$DB_DIR"
+fi
+# Disallow missing envar
+set -u
+
+./manage.py check --deploy --fail-level WARNING
+./manage.py createcachetable
+./manage.py migrate --noinput

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Bash "strict mode"
+set -euo pipefail
+IFS=$'\n\t'
+
+CMD="gunicorn --bind 0.0.0.0:$PORT lpld.wsgi:application"
+
+# Allow missing envar
+set +u
+if [[ -z "$DATABASE_URL" ]]; then
+    echo "DATABASE_URL env var not specified - Using the SQLite database"
+
+    # Wrap the default command in the litestream exec command to replicate database
+    CMD="litestream replicate -config litestream.yml --exec '$CMD'"
+fi
+# Disallow missing envar
+set -u
+
+echo "Running: $CMD"
+
+exec $(eval $CMD)

--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -1,9 +1,23 @@
+# Bash "strict mode"
 set -euo pipefail
 IFS=$'\n\t'
-# Unsetting the DATABASE_URL will make the sqlite database the active one for the commnd.
+
+# Unsetting the DATABASE_URL (with `env -u DATABASE_URL`) will make the sqlite database the active one for the command.
 # I could not make it work with `--database sqlite`.
-env -u DATABASE_URL ./manage.py migrate && \
-env -u DATABASE_URL ./manage.py flush && \
-./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > ./dbdump/dbdump.json && \
+
+echo "Transfer data from PostgreSQL to SQLite"
+
+echo "Migrate SQLite database..."
+env -u DATABASE_URL ./manage.py migrate --no-input
+
+echo "Flush SQLite database to remove data created during migrations..."
+env -u DATABASE_URL ./manage.py flush --no-input
+
+echo "Dump PostgreSQL database..."
+./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > ./dbdump/dbdump.json
+
+echo "Load database dump into SQLite..."
 env -u DATABASE_URL ./manage.py loaddata ./dbdump/dbdump.json
+
+echo "Done."
 

--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -1,0 +1,9 @@
+set -euo pipefail
+IFS=$'\n\t'
+# Unsetting the DATABASE_URL will make the sqlite database the active one for the commnd.
+# I could not make it work with `--database sqlite`.
+env -u DATABASE_URL ./manage.py migrate && \
+env -u DATABASE_URL ./manage.py flush && \
+./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > ./dbdump/dbdump.json && \
+env -u DATABASE_URL ./manage.py loaddata ./dbdump/dbdump.json
+


### PR DESCRIPTION
When looking for hosting, managed databases are often the most expensive part. Since this is a low traffic content site it is much more read than write heavy. SQLite should be a totally viable option for this. 

The only issue used to be backing up and restoring the file based SQLite database when working in containers. The problem is that the file system is ephemeral and the database file does not exist anymore after a restart and you start fresh again. 

But, now there is [Litestream](https://litestream.io/). This pushes all SQLite changes to S3 and can be used to pull it after a restart. 