### PR TITLE
Fix Heroku release command

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Bash "strict mode"
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
The command seems to be running with `sh -c <command>`. That led the following error: `./scripts/release.sh: 2: set: Illegal option -o pipefail`. I hope this is fixed by specifying the shebang to use bash.