### PR TITLE
Create database directory on every release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,18 +3,20 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+mkdir -p "$DB_DIR"
+
 # Allow missing envar
 set +u
 if [[ -z "$DATABASE_URL" ]]; then
     echo "DATABASE_URL env var not specified - Using the SQLite database"
 
-    mkdir -p "$DB_DIR"
     echo "Replicating the SQLite database from bucket"
     litestream restore -config litestream.yml -if-db-not-exists -if-replica-exists "$DB_DIR/db.sqlite3"
-    chmod -R a+rwX "$DB_DIR"
 fi
 # Disallow missing envar
 set -u
+
+chmod -R a+rwX "$DB_DIR"
 
 ./manage.py check --deploy --fail-level WARNING
 ./manage.py createcachetable


### PR DESCRIPTION
To be able to do the initial transfer of the data from Postgres to SQLite and then replicating of that data we already need the database directory to exist (so that the database is written into it).

Before, the directory was only created when there is no DATABASE_URL set and thus SQLite shall be used. As explained above, we need the directory to exist for the initial trasnfer too.