### PR TITLE
Create DB_DIR in transfer script

### DIFF
--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -7,6 +7,9 @@ IFS=$'\n\t'
 
 echo "Transfer data from PostgreSQL to SQLite"
 
+# Create the database directory for the SQLite file
+mkdir -p "$DB_DIR"
+
 echo "Migrate SQLite database..."
 env -u DATABASE_URL ./manage.py migrate --no-input
 


### PR DESCRIPTION
This is really the script that needs that directory for the first time, so I need to be sure that the directory exists.

The release script does not run on the one-off app servers, so I can not rely on that script to create the directory.