### PR TITLE
Fix database dir creation and release commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV POETRY_HOME=/home/lpld/poetry
 ENV PATH=${POETRY_HOME}/bin:$PATH \
     # Ensure dependencies are available globally (without having to mess with the poetry's venvs)
     POETRY_VIRTUALENVS_CREATE=false \
-    DJANGO_SETTINGS_MODULE=lpld.settings
+    DJANGO_SETTINGS_MODULE=lpld.settings \
+    USE_SQLITE=false
 RUN env
 
 # Install litestream (https://litestream.io/install/debian/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,18 @@ RUN npm run build:css
 
 FROM python:3.9
 
-RUN mkdir /app
-WORKDIR /app
+RUN mkdir /app && mkdir /data
 RUN useradd -m lpld -s /bin/bash && \
-    chown -R lpld /app
+    chown -R lpld /app && \
+    chown -R lpld /data
+WORKDIR /app
 
 ENV POETRY_HOME=/home/lpld/poetry
 ENV PATH=${POETRY_HOME}/bin:$PATH \
     # Ensure dependencies are available globally (without having to mess with the poetry's venvs)
     POETRY_VIRTUALENVS_CREATE=false \
     DJANGO_SETTINGS_MODULE=lpld.settings \
+    DB_DIR=/data \
     USE_SQLITE=false
 RUN env
 

--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -163,6 +163,9 @@ DATABASE_URL = os.environ.get(
     "DATABASE_URL",
     SQLITE_URL,
 )
+if os.environ.get("USE_SQLITE", "false") == "true":
+    # Force use of SQLite with environment variable.
+    DATABASE_URL = SQLITE_URL
 DATABASES = {}
 DATABASES["default"] = dj_database_url.parse(DATABASE_URL)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-./manage.py check --deploy --fail-level WARNING
-./manage.py createcachetable
-./manage.py migrate --noinput
+if [ $USE_SQLITE != "true" ]; then
+    ./manage.py check --deploy --fail-level WARNING
+    ./manage.py createcachetable
+    ./manage.py migrate --noinput
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,21 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-mkdir -p "$DB_DIR"
-
-# Allow missing envar
-set +u
-if [[ -z "$DATABASE_URL" ]]; then
-    echo "DATABASE_URL env var not specified - Using the SQLite database"
-
-    echo "Replicating the SQLite database from bucket"
-    litestream restore -config litestream.yml -if-db-not-exists -if-replica-exists "$DB_DIR/db.sqlite3"
-fi
-# Disallow missing envar
-set -u
-
-chmod -R a+rwX "$DB_DIR"
-
 ./manage.py check --deploy --fail-level WARNING
 ./manage.py createcachetable
 ./manage.py migrate --noinput

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,9 +6,7 @@ IFS=$'\n\t'
 CMD="gunicorn --bind 0.0.0.0:$PORT lpld.wsgi:application"
 
 if [ $USE_SQLITE = "true" ]; then
-    echo "DATABASE_URL env var not specified - using the SQLite database."
-
-    mkdir -p "$DB_DIR"
+    echo "Use of SQLite database configured."
 
     echo "Restoring the SQLite database from bucket."
     litestream restore -config litestream.yml -if-db-not-exists -if-replica-exists "$DB_DIR/db.sqlite3"

--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 echo "Transfer data from PostgreSQL to SQLite"
 
-$DUMP_FILE=$DB_DIR/dbdump.json
+DUMP_FILE=$DB_DIR/dbdump.json
 
 echo "Migrate SQLite database..."
 USE_SQLITE=true ./manage.py migrate --no-input

--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -2,26 +2,23 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Unsetting the DATABASE_URL (with `env -u DATABASE_URL`) will make the sqlite database the active one for the command.
-# I could not make it work with `--database sqlite`.
-
 echo "Transfer data from PostgreSQL to SQLite"
 
 # Create the database directory for the SQLite file
 mkdir -p "$DB_DIR"
 
 echo "Migrate SQLite database..."
-env -u DATABASE_URL ./manage.py migrate --no-input
+USE_SQLITE=true ./manage.py migrate --no-input
 
 echo "Flush SQLite database to remove data created during migrations..."
-env -u DATABASE_URL ./manage.py flush --no-input
+USE_SQLITE=true ./manage.py flush --no-input
 
 echo "Dump PostgreSQL database..."
 mkdir -p ./dbdump
 ./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > ./dbdump/dbdump.json
 
 echo "Load database dump into SQLite..."
-env -u DATABASE_URL ./manage.py loaddata ./dbdump/dbdump.json
+USE_SQLITE=true ./manage.py loaddata ./dbdump/dbdump.json
 
 echo "Done."
 

--- a/scripts/transfer-data-to-sqlite.sh
+++ b/scripts/transfer-data-to-sqlite.sh
@@ -4,8 +4,7 @@ IFS=$'\n\t'
 
 echo "Transfer data from PostgreSQL to SQLite"
 
-# Create the database directory for the SQLite file
-mkdir -p "$DB_DIR"
+$DUMP_FILE=$DB_DIR/dbdump.json
 
 echo "Migrate SQLite database..."
 USE_SQLITE=true ./manage.py migrate --no-input
@@ -14,11 +13,10 @@ echo "Flush SQLite database to remove data created during migrations..."
 USE_SQLITE=true ./manage.py flush --no-input
 
 echo "Dump PostgreSQL database..."
-mkdir -p ./dbdump
-./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > ./dbdump/dbdump.json
+./manage.py dumpdata --natural-foreign --natural-primary --exclude "wagtailcore.PageLogEntry" --indent 4 > $DUMP_FILE
 
 echo "Load database dump into SQLite..."
-USE_SQLITE=true ./manage.py loaddata ./dbdump/dbdump.json
+USE_SQLITE=true ./manage.py loaddata $DUMP_FILE
 
 echo "Done."
 


### PR DESCRIPTION
This PR adds the database directory (identified by `$DB_DIR`) in the docker image and runs the release commands in the run script when running with SQLite. 

These changes where necessary, because the release commands on Heroku run in a different container than app is actually run. This means no file system changes transfer from the release phase to the run phase. This means when running with SQLite I need to do things like migrations after the database is restored to the run container and before the app is started. Thus in the run script. 

Also, I was creating the database directory in several places. It seemed just easier to build it directly into the image so that I can rely on the directory already existing. 

Also, because it is not possible to remove the `DATABASE_URL` environment setting on Heroku without deleting the database, I needed an other mechanism that allows me to disable the use of the connected database and force the use of SQLite. This can now be achieved with `USE_SQLITE=true`.

