### PR TITLE
Fix preview when using basic auth

### DIFF
--- a/lpld/settings.py
+++ b/lpld/settings.py
@@ -305,6 +305,8 @@ BASIC_AUTH_LOGIN = os.environ.get("BASIC_AUTH_LOGIN")
 BASIC_AUTH_PASSWORD = os.environ.get("BASIC_AUTH_PASSWORD")
 if BASIC_AUTH_LOGIN and BASIC_AUTH_PASSWORD:
     MIDDLEWARE = ["baipw.middleware.BasicAuthIPWhitelistMiddleware"] + MIDDLEWARE
+    # Wagtail requires Authorization header to be present for the previews
+    BASIC_AUTH_DISABLE_CONSUMING_AUTHORIZATION_HEADER = True
 
 if not DEBUG:
     CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
Before, when trying to use preview on a site that has basic auth enabled (e.g. on staging to avoid indexing) I would keep getting prompted with requests to enter the basic auth credentials.

It turns out this is caused by the auth information normally getting stripped from the request headers. Luckily there is a setting to prevent this. Now the the basic aut h credentials work for the other requests too.
  
Fixes #81 