### PR TITLE
Ignore directories in the bucket content listing

### DIFF
--- a/scripts/download_bucket.py
+++ b/scripts/download_bucket.py
@@ -18,8 +18,15 @@ client = session.client(
 )
 
 response = client.list_objects(Bucket=bucket_name)
+print(response["Contents"])
 for obj in response["Contents"]:
     filepath = obj["Key"]
+
+    if filepath.endswith("/"):
+        # We can ignore the directory entries we get in the response. The directories
+        # get created as parents of files anyhow.
+        continue
+
     local_filepath = target_directory / filepath
 
     # Create sub-directories if necessary


### PR DESCRIPTION
This seems like a new addition to the listing of a bucket since I originally wrote this script. The directories don't need to be created, because we create them based on the files we are loading afterwards.