### PR TITLE
Enable heroku exec

### DIFF
--- a/.profile.d/heroku-exec.sh
+++ b/.profile.d/heroku-exec.sh
@@ -1,0 +1,1 @@
+[ -z "$SSH_CLIENT" ] && source <(curl --fail --retry 3 -sSL "$HEROKU_EXEC_URL")

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN npm run build:css
 
 FROM python:3.9 as backend
 
+# Make bash default shell
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
 RUN mkdir /app && mkdir /data
 RUN useradd -m lpld -s /bin/bash && \
     chown -R lpld /app && \


### PR DESCRIPTION
This should allow me to connect directly to connect into the running container. This is important, because with lightstream running in a different container uses different data. 

https://devcenter.heroku.com/articles/exec#using-with-docker