### PR TITLE
Add specific image platform

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       target: backend-development
+      # Platforms need to be specified for the build to work on Apple Silicon Macs.
+      platforms:
+        - linux/amd64
     command: ["tail", "-f", "/dev/null"]
     env_file:
       - .env
@@ -17,6 +20,9 @@ services:
     build:
       context: .
       target: frontend
+      # Platforms need to be specified for the build to work on Apple Silicon Macs.
+      platforms:
+        - linux/amd64
     command: ["tail", "-f", "/dev/null"]
     env_file:
       - .env


### PR DESCRIPTION
Without this specification, the image is chosen based on the host. I don't want that. The image should be what I define