### PR TITLE
Default Dockerfile to amd but use arm in compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as frontend
+FROM node:18-bookworm-slim as frontend
 
 WORKDIR /home/node/app
 
@@ -32,8 +32,9 @@ ENV PATH=${POETRY_HOME}/bin:$PATH \
 RUN env
 
 # Install litestream (https://litestream.io/install/debian/)
-RUN wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-amd64.deb
-RUN dpkg -i litestream-v0.3.9-linux-amd64.deb
+ARG PLATFORM=amd64
+RUN wget https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-$PLATFORM.deb
+RUN dpkg -i litestream-v0.3.9-linux-$PLATFORM.deb
 
 # Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,8 @@ services:
     build:
       context: .
       target: backend-development
-      # Platforms need to be specified for the build to work on Apple Silicon Macs.
-      platforms:
-        - linux/amd64
+      args:
+        - PLATFORM=arm64
     command: ["tail", "-f", "/dev/null"]
     env_file:
       - .env
@@ -20,9 +19,6 @@ services:
     build:
       context: .
       target: frontend
-      # Platforms need to be specified for the build to work on Apple Silicon Macs.
-      platforms:
-        - linux/amd64
     command: ["tail", "-f", "/dev/null"]
     env_file:
       - .env


### PR DESCRIPTION
Before, I was forcing the platform to be amd64 because that was the platform that I was installing Litestream for. 

Turns out, there is a arm64 version of Litestream. This means I have use the fitting platform for the image but have to pull the proper Litestream verison. 

This is what this PR is setting up. 