### PR TITLE
Use inline-block instead of flex to fix underline issue in safari

### DIFF
--- a/lpld/templates/atoms/chevron-link/chevron-link.html
+++ b/lpld/templates/atoms/chevron-link/chevron-link.html
@@ -6,9 +6,8 @@
                 {{ word }}
             {% else %}
                 {# Span wrapper to avoid line-break between icon and last word. #}
-                <span class="inline-flex items-center underline decoration-1 group-hover:decoration-2">
-                    {{ word }}
-                    {% heroicon_mini "chevron-right" class="transition ease-linear group-hover:translate-x-0.5 delay-[10] duration-[10]" %}
+                <span class="inline-block nowrap underline decoration-1 group-hover:decoration-2">
+                    {{ word }}{% heroicon_mini "chevron-right" class="inline-block transition ease-linear group-hover:translate-x-0.5 delay-[10] duration-[10]" %}
                 </span>
             {% endif %}
         {% endfor %}

--- a/lpld/templates/atoms/chevron-link/chevron-link.yaml
+++ b/lpld/templates/atoms/chevron-link/chevron-link.yaml
@@ -1,3 +1,3 @@
 context:
-  text: 'Listing link title'
+  text: 'This is a much longer link title to check linebreaks'
   href: 'https://www.example.com'


### PR DESCRIPTION
This is a known bug: https://bugs.webkit.org/show_bug.cgi?id=276156